### PR TITLE
Delay load mac_say

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ optional arguments:
   --slots-only          Only show stores with Curbside slots
   --interval INTERVAL   Interval at which the daemon should check availability
                         (in minutes, default=5)
-  --speak               Speak when a slot is found
+  --speak               Speak when a slot is found.  Ignored if not macOS.
   --email-to EMAIL_TO   The address to email when slots are found
   --email-username EMAIL_USERNAME
                         Your Gmail username

--- a/find_store.py
+++ b/find_store.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-from sys import exit
+from sys import exit, platform
 from time import sleep
 from dateutil.parser import parse
 from datetime import datetime
@@ -235,7 +235,7 @@ class Search:
         print("email_username: " + str(self.email_username))
 
     def speak_num_curbside_slots(self):
-        if self.speak:
+        if self.speak and platform == 'darwin':
             import mac_say
             if self.num_curbside_slots > 0:
                 if self.detail or self.store_id:
@@ -452,7 +452,7 @@ if __name__ == '__main__':
         default=5)
     parser.add_argument(
         "--speak",
-        help="Speak when a slot is found",
+        help="Speak when a slot is found.  Ignored if not macOS.",
         action='store_true')
     parser.add_argument(
         "--email-to",

--- a/find_store.py
+++ b/find_store.py
@@ -9,7 +9,6 @@ import argparse
 import json
 import smtplib, ssl
 import requests
-import mac_say
 import os
 
 __author__ = "Blayne Dreier"

--- a/find_store.py
+++ b/find_store.py
@@ -9,7 +9,6 @@ import argparse
 import json
 import smtplib, ssl
 import requests
-import mac_say
 
 __author__ = "Blayne Dreier"
 __copyright__ = "Copyright 2020"
@@ -237,6 +236,7 @@ class Search:
 
     def speak_num_curbside_slots(self):
         if self.speak:
+            import mac_say
             if self.num_curbside_slots > 0:
                 if self.detail or self.store_id:
                     try:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 python-dateutil
 requests
-mac-say
+mac-say; sys_platform == 'darwin'


### PR DESCRIPTION
mac_say package won't properly install on Ubuntu-based distros (but ironically installs fine on Windows, but doesn't run properly)